### PR TITLE
Add approval/notification/audit models and ticket utilities; extend users and catalog

### DIFF
--- a/db_functions.py
+++ b/db_functions.py
@@ -14,7 +14,7 @@ import string
 from sqlalchemy import text
 from werkzeug.security import generate_password_hash, check_password_hash
 from models import db, User, Password, UserRole, WorkGroup, UserWorkGroup, gen_uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +139,8 @@ def generate_ticket_number() -> str:
 # ---------------------------------------------------------------------------
 def create_user_db(last_name, first_name, middle_name, email, mobile,
                    work_phone, gender, title, department, company,
-                   role='user', work_group_uid=None, creator_uid=None) -> tuple:
+                   role='user', work_group_uid=None, manager_uid=None,
+                   creator_uid=None, avatar='cat') -> tuple:
     """
     Creates a user.  Tries sm.create_user() first; falls back to manual INSERT.
 
@@ -193,6 +194,8 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
         title=title or None,
         department=department or None,
         company=company or None,
+        manager_uid=manager_uid,
+        avatar=avatar or 'cat',
         create_by=sys_uid,
         update_by=sys_uid,
     )
@@ -296,3 +299,76 @@ def add_ticket_history(ticket_uid, field_name, old_value, new_value, changed_by_
         changed_by=changed_by_uid,
     )
     db.session.add(h)
+
+
+def compute_deadline(catalog):
+    """Estimate ticket deadline from linked SLA policy."""
+    hours = 24
+    if getattr(catalog, 'sla', None) and getattr(catalog.sla, 'resolution_time_hours', None):
+        hours = catalog.sla.resolution_time_hours
+    elif getattr(catalog, 'priority', None) == 'critical':
+        hours = 4
+    elif getattr(catalog, 'priority', None) == 'high':
+        hours = 8
+    elif getattr(catalog, 'priority', None) == 'low':
+        hours = 72
+    return datetime.utcnow() + timedelta(hours=hours)
+
+
+def notify(user_uid, message, ticket_uid=None):
+    from models import Notification
+    db.session.add(Notification(
+        user_uid=user_uid,
+        message=message,
+        ticket_uid=ticket_uid,
+    ))
+
+
+def notify_ticket_update(ticket, message, exclude_uid=None):
+    recipients = {ticket.requester_uid, ticket.recipient_uid, ticket.performer_uid}
+    recipients = {uid for uid in recipients if uid and uid != exclude_uid}
+    for uid in recipients:
+        notify(uid, message, ticket_uid=ticket.ticket_uid)
+
+
+def audit(user_uid, action, entity_type=None, entity_uid=None, details=None, ip=None):
+    from models import AuditLog
+    db.session.add(AuditLog(
+        user_uid=user_uid,
+        action=action,
+        entity_type=entity_type,
+        entity_uid=entity_uid,
+        details=details,
+        ip_address=ip,
+    ))
+
+
+def create_approval_chain(ticket, catalog, requester):
+    from models import TicketApproval, User
+    approver_uid = requester.manager_uid
+    if not approver_uid:
+        manager = User.query.join(UserRole).filter(UserRole.role.in_(['manager', 'admin'])).first()
+        approver_uid = manager.user_uid if manager else None
+    db.session.add(TicketApproval(
+        ticket_uid=ticket.ticket_uid,
+        step_order=1,
+        step_name='Согласование руководителя',
+        approver_uid=approver_uid,
+        status='pending',
+    ))
+
+
+def process_approval_decision(ticket, approval, decision, comment, actor_uid):
+    valid = {'approved', 'rejected'}
+    if decision not in valid:
+        raise ValueError('Недопустимое решение согласования')
+    approval.status = decision
+    approval.comment = comment or None
+    approval.decided_at = datetime.utcnow()
+    add_ticket_history(ticket.ticket_uid, 'approval', 'pending', decision, actor_uid)
+    if decision == 'approved':
+        ticket.status = 'new'
+        notify_ticket_update(ticket, f'Заявка {ticket.ticket_number} согласована', exclude_uid=actor_uid)
+    else:
+        ticket.status = 'rejected'
+        notify_ticket_update(ticket, f'Заявка {ticket.ticket_number} отклонена', exclude_uid=actor_uid)

--- a/models.py
+++ b/models.py
@@ -29,6 +29,8 @@ class User(UserMixin, db.Model):
     title = db.Column(db.String(255), nullable=True)
     department = db.Column(db.String(255), nullable=True)
     company = db.Column(db.String(255), nullable=True)
+    manager_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    avatar = db.Column(db.String(32), nullable=False, default='cat')
     work_status = db.Column(db.String(20), nullable=True)
     is_vip = db.Column(db.Boolean, default=False)
     is_deactivated = db.Column(db.Boolean, default=False)
@@ -81,6 +83,17 @@ class User(UserMixin, db.Model):
         if link:
             return link.work_group
         return None
+
+    def all_work_groups(self):
+        return [l.work_group for l in self.work_group_links.order_by(UserWorkGroup.assigned_date).all()]
+
+    def avatar_emoji(self):
+        mapping = {
+            'cat': '🐱', 'dog': '🐶', 'fox': '🦊', 'bear': '🐻', 'penguin': '🐧',
+            'owl': '🦉', 'tiger': '🐯', 'rabbit': '🐰', 'wolf': '🐺', 'panda': '🐼',
+            'frog': '🐸', 'lion': '🦁', 'koala': '🐨', 'duck': '🦆', 'dragon': '🐲',
+        }
+        return mapping.get(self.avatar or 'cat', '🙂')
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +194,8 @@ class ServiceCatalog(db.Model):
                                nullable=True)
     ticket_type = db.Column(db.String(100), default='service_request')
     priority = db.Column(db.String(20), default='medium')
+    approval_required = db.Column(db.Boolean, default=False)
+    is_active = db.Column(db.Boolean, default=True)
     sla_uid = db.Column(db.String(36), db.ForeignKey('sm.sla_policies.sla_uid'), nullable=True)
     create_date = db.Column(db.DateTime, default=datetime.utcnow)
     update_date = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -215,6 +230,7 @@ class Ticket(db.Model):
     performer_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
     status = db.Column(db.String(50), default='new', nullable=False)
     priority = db.Column(db.String(20), default='medium')
+    deadline_at = db.Column(db.DateTime, nullable=True)
     resolved_at = db.Column(db.DateTime, nullable=True)
     closed_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
@@ -232,6 +248,14 @@ class Ticket(db.Model):
                                   foreign_keys='Attachment.ticket_uid')
 
     creator = db.relationship('User', foreign_keys=[created_by])
+
+    approvals = db.relationship('TicketApproval', backref='ticket', lazy='dynamic',
+                                cascade='all, delete-orphan',
+                                foreign_keys='TicketApproval.ticket_uid')
+
+    def is_overdue(self):
+        return bool(self.deadline_at and self.status not in ('resolved', 'closed', 'cancelled')
+                    and self.deadline_at < datetime.utcnow())
 
 
 # ---------------------------------------------------------------------------
@@ -289,3 +313,87 @@ class Attachment(db.Model):
     upload_date = db.Column(db.DateTime, default=datetime.utcnow)
 
     uploader = db.relationship('User', foreign_keys=[uploaded_by])
+
+
+class ApprovalRoute(db.Model):
+    __tablename__ = 'approval_routes'
+    __table_args__ = {'schema': 'sm'}
+
+    route_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    catalog_uid = db.Column(db.String(36), db.ForeignKey('sm.service_catalog.catalog_uid'), nullable=False)
+    route_name = db.Column(db.String(200), nullable=False)
+    is_active = db.Column(db.Boolean, default=True)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+    created_by = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+
+
+class ApprovalStep(db.Model):
+    __tablename__ = 'approval_steps'
+    __table_args__ = {'schema': 'sm'}
+
+    step_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    route_uid = db.Column(db.String(36), db.ForeignKey('sm.approval_routes.route_uid'), nullable=False)
+    step_order = db.Column(db.Integer, nullable=False, default=1)
+    step_name = db.Column(db.String(200), nullable=True)
+    approver_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    approver_role = db.Column(db.String(32), nullable=True)
+
+
+class TicketApproval(db.Model):
+    __tablename__ = 'ticket_approvals'
+    __table_args__ = {'schema': 'sm'}
+
+    approval_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    ticket_uid = db.Column(db.String(36), db.ForeignKey('sm.tickets.ticket_uid', ondelete='CASCADE'), nullable=False)
+    step_order = db.Column(db.Integer, nullable=False, default=1)
+    step_name = db.Column(db.String(200), nullable=True)
+    approver_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    status = db.Column(db.String(20), nullable=False, default='pending')
+    comment = db.Column(db.Text, nullable=True)
+    decided_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    approver = db.relationship('User', foreign_keys=[approver_uid])
+
+
+class Notification(db.Model):
+    __tablename__ = 'notifications'
+    __table_args__ = {'schema': 'sm'}
+
+    notification_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    user_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+    ticket_uid = db.Column(db.String(36), db.ForeignKey('sm.tickets.ticket_uid'), nullable=True)
+    message = db.Column(db.Text, nullable=False)
+    is_read = db.Column(db.Boolean, default=False)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    ticket_rel = db.relationship('Ticket', foreign_keys=[ticket_uid])
+
+
+class TicketTemplate(db.Model):
+    __tablename__ = 'ticket_templates'
+    __table_args__ = {'schema': 'sm'}
+
+    template_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    template_name = db.Column(db.String(200), nullable=False)
+    catalog_uid = db.Column(db.String(36), db.ForeignKey('sm.service_catalog.catalog_uid'), nullable=False)
+    summary = db.Column(db.String(500), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    priority = db.Column(db.String(20), nullable=True)
+    is_public = db.Column(db.Boolean, default=False)
+    created_by = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class AuditLog(db.Model):
+    __tablename__ = 'audit_log'
+    __table_args__ = {'schema': 'sm'}
+
+    audit_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    user_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    action = db.Column(db.String(64), nullable=False)
+    entity_type = db.Column(db.String(64), nullable=True)
+    entity_uid = db.Column(db.String(36), nullable=True)
+    details = db.Column(db.Text, nullable=True)
+    ip_address = db.Column(db.String(64), nullable=True)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Werkzeug==3.0.3
 psycopg2-binary
-SQLAlchemy==2.0.30
+SQLAlchemy==2.0.44


### PR DESCRIPTION
### Motivation
- Introduce application-level approval, notification and audit capabilities and wire them into ticket handling and user records.
- Extend user and catalog models with manager linkage, avatar and approval-related flags to support routing and UI features.
- Provide Python-side utilities for deadlines, notifications, approvals and auditing to operate when DB stored procedures are not used or unavailable.

### Description
- Added new columns to `User`: `manager_uid` and `avatar`, and helper methods `all_work_groups()` and `avatar_emoji()` on the `User` model.
- Extended `ServiceCatalog` with `approval_required` and `is_active` flags, and added `deadline_at` and `approvals` relationship plus `is_overdue()` to `Ticket`.
- Introduced new models: `ApprovalRoute`, `ApprovalStep`, `TicketApproval`, `Notification`, `TicketTemplate`, and `AuditLog` to support approval workflows, notifications and audit logging.
- Enhanced `create_user_db` signature and Python fallback to accept `manager_uid` and `avatar`, and set these fields when creating users; adjusted imports to include `timedelta`.
- Added utility functions in `db_functions.py`: `compute_deadline()`, `notify()`, `notify_ticket_update()`, `audit()`, `create_approval_chain()`, and `process_approval_decision()` to manage SLA-based deadlines, notifications, audit entries and simple approval processing; retained existing behaviors like `generate_ticket_number()` and password handling.
- Bumped `SQLAlchemy` from `2.0.30` to `2.0.44` in `requirements.txt`.

### Testing
- Ran the project's automated test suite via `pytest`, which completed successfully on the changes.
- Verified that model imports and new relationships initialize without errors in the application test environment using the existing test database configuration.
- Executed core user creation and password verification unit tests to ensure `create_user_db` fallback and `_set_password_hash` logic still behave correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d134b6b94483238cc9a4de498edc72)