### PR TITLE
Add approvals, notifications, audit models and DB migrations; deadline & avatar support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.env
+uploads/
+instance/
+.DS_Store

--- a/app.py
+++ b/app.py
@@ -157,7 +157,7 @@ def priority_label_filter(p):
 @app.template_filter('datefmt')
 def datefmt_filter(dt, fmt='%d.%m.%Y %H:%M'):
     if not dt:
-        return 'E2014'
+        return '—'
     return dt.strftime(fmt)
 
 
@@ -180,9 +180,101 @@ def inject_globals():
 def init_db():
     """Initialize schema and default data."""
     from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
     db.session.execute(text('CREATE SCHEMA IF NOT EXISTS sm'))
     db.session.commit()
-    db.create_all()
+    try:
+        db.create_all()
+    except SQLAlchemyError:
+        # Existing installations can have UUID columns in base tables while
+        # ORM models use String(36). In that case create_all() may fail when
+        # creating new FK tables. Continue with explicit SQL below.
+        db.session.rollback()
+
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.approval_routes (
+            route_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            route_name varchar(200) NOT NULL,
+            catalog_uid uuid NOT NULL REFERENCES sm.service_catalog(catalog_uid) ON DELETE CASCADE,
+            is_active bool DEFAULT true NULL,
+            create_date timestamptz DEFAULT CURRENT_TIMESTAMP NULL,
+            create_by uuid NOT NULL REFERENCES sm.users(user_uid)
+        )
+    """))
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.approval_steps (
+            step_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            route_uid uuid NOT NULL REFERENCES sm.approval_routes(route_uid) ON DELETE CASCADE,
+            step_order int4 NOT NULL DEFAULT 1,
+            step_name varchar(200) NULL,
+            approver_uid uuid NULL REFERENCES sm.users(user_uid),
+            approver_role varchar(32) NULL
+        )
+    """))
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.ticket_approvals (
+            approval_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            ticket_uid uuid NOT NULL REFERENCES sm.tickets(ticket_uid) ON DELETE CASCADE,
+            step_order int4 NOT NULL DEFAULT 1,
+            step_name varchar(200) NULL,
+            approver_uid uuid NULL REFERENCES sm.users(user_uid),
+            status varchar(20) NOT NULL DEFAULT 'pending',
+            comment text NULL,
+            decided_at timestamptz NULL,
+            create_date timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+        )
+    """))
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.notifications (
+            notification_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_uid uuid NOT NULL REFERENCES sm.users(user_uid) ON DELETE CASCADE,
+            message text NOT NULL,
+            ticket_uid uuid NULL REFERENCES sm.tickets(ticket_uid) ON DELETE SET NULL,
+            is_read bool DEFAULT false NULL,
+            create_date timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+        )
+    """))
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.ticket_templates (
+            template_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            template_name varchar(200) NOT NULL,
+            catalog_uid uuid NOT NULL REFERENCES sm.service_catalog(catalog_uid) ON DELETE CASCADE,
+            summary varchar(500) NOT NULL,
+            description text NOT NULL,
+            priority varchar(20) NULL,
+            created_by uuid NOT NULL REFERENCES sm.users(user_uid),
+            is_public bool DEFAULT false NULL,
+            create_date timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+        )
+    """))
+    db.session.execute(text("""
+        CREATE TABLE IF NOT EXISTS sm.audit_log (
+            audit_uid uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_uid uuid NULL REFERENCES sm.users(user_uid) ON DELETE SET NULL,
+            action varchar(64) NOT NULL,
+            entity_type varchar(64) NULL,
+            entity_uid uuid NULL,
+            details text NULL,
+            ip_address varchar(64) NULL,
+            create_date timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+        )
+    """))
+    # Lightweight compatibility migration for older databases.
+    db.session.execute(text("""
+        ALTER TABLE IF EXISTS sm.users
+            ADD COLUMN IF NOT EXISTS manager_uid uuid NULL,
+            ADD COLUMN IF NOT EXISTS avatar varchar(32) NULL DEFAULT 'cat'
+    """))
+    db.session.execute(text("""
+        ALTER TABLE IF EXISTS sm.service_catalog
+            ADD COLUMN IF NOT EXISTS is_active bool DEFAULT true,
+            ADD COLUMN IF NOT EXISTS approval_required bool DEFAULT false
+    """))
+    db.session.execute(text("""
+        ALTER TABLE IF EXISTS sm.tickets
+            ADD COLUMN IF NOT EXISTS deadline_at timestamptz NULL
+    """))
+    db.session.commit()
 
     SYS = '00000000-0000-0000-0000-000000000001'
 

--- a/db_functions.py
+++ b/db_functions.py
@@ -13,8 +13,10 @@ import random
 import string
 from sqlalchemy import text
 from werkzeug.security import generate_password_hash, check_password_hash
-from models import db, User, Password, UserRole, WorkGroup, UserWorkGroup, gen_uuid
-from datetime import datetime
+from models import (db, User, Password, UserRole, WorkGroup, UserWorkGroup,
+                    Notification, AuditLog, TicketApproval, ApprovalRoute, ApprovalStep,
+                    gen_uuid)
+from datetime import datetime, timedelta
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +141,8 @@ def generate_ticket_number() -> str:
 # ---------------------------------------------------------------------------
 def create_user_db(last_name, first_name, middle_name, email, mobile,
                    work_phone, gender, title, department, company,
-                   role='user', work_group_uid=None, creator_uid=None) -> tuple:
+                   role='user', work_group_uid=None, manager_uid=None,
+                   creator_uid=None, avatar='cat') -> tuple:
     """
     Creates a user.  Tries sm.create_user() first; falls back to manual INSERT.
 
@@ -167,6 +170,8 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
                 _set_password_hash(user.user_uid, temp_password)
                 _ensure_role(user.user_uid, role, creator_uid)
                 _ensure_work_group(user.user_uid, work_group_uid)
+                user.manager_uid = manager_uid
+                user.avatar = avatar or user.avatar or 'cat'
                 db.session.commit()
                 return user_name, temp_password
 
@@ -193,6 +198,8 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
         title=title or None,
         department=department or None,
         company=company or None,
+        manager_uid=manager_uid,
+        avatar=avatar or 'cat',
         create_by=sys_uid,
         update_by=sys_uid,
     )
@@ -296,3 +303,111 @@ def add_ticket_history(ticket_uid, field_name, old_value, new_value, changed_by_
         changed_by=changed_by_uid,
     )
     db.session.add(h)
+
+
+def compute_deadline(catalog):
+    """Estimate ticket deadline from linked SLA policy."""
+    hours = 24
+    if getattr(catalog, 'sla', None) and getattr(catalog.sla, 'resolution_time_hours', None):
+        hours = catalog.sla.resolution_time_hours
+    elif getattr(catalog, 'priority', None) == 'critical':
+        hours = 4
+    elif getattr(catalog, 'priority', None) == 'high':
+        hours = 8
+    elif getattr(catalog, 'priority', None) == 'low':
+        hours = 72
+    return datetime.utcnow() + timedelta(hours=hours)
+
+
+def notify(user_uid, message, ticket_uid=None):
+    db.session.add(Notification(
+        user_uid=user_uid,
+        message=message,
+        ticket_uid=ticket_uid,
+    ))
+
+
+def notify_ticket_update(ticket, message, exclude_uid=None):
+    recipients = {ticket.requester_uid, ticket.recipient_uid, ticket.performer_uid}
+    recipients = {uid for uid in recipients if uid and uid != exclude_uid}
+    for uid in recipients:
+        notify(uid, message, ticket_uid=ticket.ticket_uid)
+
+
+def audit(user_uid, action, entity_type=None, entity_uid=None, details=None, ip=None):
+    db.session.add(AuditLog(
+        user_uid=user_uid,
+        action=action,
+        entity_type=entity_type,
+        entity_uid=entity_uid,
+        details=details,
+        ip_address=ip,
+    ))
+
+
+def create_approval_chain(ticket, catalog, requester):
+    from models import User
+    route = ApprovalRoute.query.filter_by(catalog_uid=catalog.catalog_uid, is_active=True).first()
+    if route:
+        steps = ApprovalStep.query.filter_by(route_uid=route.route_uid).order_by(ApprovalStep.step_order).all()
+        for step in steps:
+            approver_uid = step.approver_uid
+            if not approver_uid and step.approver_role:
+                candidate = User.query.join(UserRole).filter(
+                    UserRole.role == step.approver_role,
+                    User.is_deactivated == False
+                ).first()
+                approver_uid = candidate.user_uid if candidate else None
+            db.session.add(TicketApproval(
+                ticket_uid=ticket.ticket_uid,
+                step_order=step.step_order,
+                step_name=step.step_name or f'Шаг {step.step_order}',
+                approver_uid=approver_uid,
+                status='pending',
+            ))
+        return
+
+    approver_uid = requester.manager_uid
+    if not approver_uid:
+        manager = User.query.join(UserRole).filter(UserRole.role.in_(['manager', 'admin'])).first()
+        approver_uid = manager.user_uid if manager else None
+    db.session.add(TicketApproval(
+        ticket_uid=ticket.ticket_uid,
+        step_order=1,
+        step_name='Согласование руководителя',
+        approver_uid=approver_uid,
+        status='pending',
+    ))
+
+
+def process_approval_decision(ticket, approval, decision, comment, actor_uid):
+    valid = {'approved', 'rejected'}
+    if decision not in valid:
+        raise ValueError('Недопустимое решение согласования')
+    old_status = approval.status
+    approval.status = decision
+    approval.comment = comment or None
+    approval.decided_at = datetime.utcnow()
+    add_ticket_history(ticket.ticket_uid, 'approval', old_status, decision, actor_uid)
+
+    if decision == 'rejected':
+        previous = ticket.status
+        ticket.status = 'rejected'
+        add_ticket_history(ticket.ticket_uid, 'status', previous, 'rejected', actor_uid)
+        notify_ticket_update(ticket, f'Заявка {ticket.ticket_number} отклонена', exclude_uid=actor_uid)
+        return
+
+    pending = TicketApproval.query.filter_by(ticket_uid=ticket.ticket_uid, status='pending').order_by(
+        TicketApproval.step_order
+    ).all()
+    if pending:
+        nxt = pending[0]
+        if nxt.approver_uid:
+            notify(nxt.approver_uid,
+                   f'Требуется согласование заявки {ticket.ticket_number}',
+                   ticket_uid=ticket.ticket_uid)
+    else:
+        previous = ticket.status
+        ticket.status = 'approved'
+        add_ticket_history(ticket.ticket_uid, 'status', previous, 'approved', actor_uid)
+        notify_ticket_update(ticket, f'Заявка {ticket.ticket_number} согласована', exclude_uid=actor_uid)

--- a/models.py
+++ b/models.py
@@ -4,6 +4,11 @@ from flask_login import UserMixin
 from datetime import datetime
 
 db = SQLAlchemy()
+AVATAR_EMOJIS = {
+    'cat': '🐱', 'dog': '🐶', 'fox': '🦊', 'bear': '🐻', 'penguin': '🐧',
+    'owl': '🦉', 'tiger': '🐯', 'rabbit': '🐰', 'wolf': '🐺', 'panda': '🐼',
+    'frog': '🐸', 'lion': '🦁', 'koala': '🐨', 'duck': '🦆', 'dragon': '🐲',
+}
 
 
 def gen_uuid():
@@ -29,6 +34,8 @@ class User(UserMixin, db.Model):
     title = db.Column(db.String(255), nullable=True)
     department = db.Column(db.String(255), nullable=True)
     company = db.Column(db.String(255), nullable=True)
+    manager_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    avatar = db.Column(db.String(32), nullable=False, default='cat')
     work_status = db.Column(db.String(20), nullable=True)
     is_vip = db.Column(db.Boolean, default=False)
     is_deactivated = db.Column(db.Boolean, default=False)
@@ -81,6 +88,12 @@ class User(UserMixin, db.Model):
         if link:
             return link.work_group
         return None
+
+    def all_work_groups(self):
+        return [l.work_group for l in self.work_group_links.order_by(UserWorkGroup.assigned_date).all()]
+
+    def avatar_emoji(self):
+        return AVATAR_EMOJIS.get(self.avatar or 'cat', '🙂')
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +194,8 @@ class ServiceCatalog(db.Model):
                                nullable=True)
     ticket_type = db.Column(db.String(100), default='service_request')
     priority = db.Column(db.String(20), default='medium')
+    approval_required = db.Column(db.Boolean, default=False)
+    is_active = db.Column(db.Boolean, default=True)
     sla_uid = db.Column(db.String(36), db.ForeignKey('sm.sla_policies.sla_uid'), nullable=True)
     create_date = db.Column(db.DateTime, default=datetime.utcnow)
     update_date = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -215,6 +230,7 @@ class Ticket(db.Model):
     performer_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
     status = db.Column(db.String(50), default='new', nullable=False)
     priority = db.Column(db.String(20), default='medium')
+    deadline_at = db.Column(db.DateTime, nullable=True)
     resolved_at = db.Column(db.DateTime, nullable=True)
     closed_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
@@ -232,6 +248,14 @@ class Ticket(db.Model):
                                   foreign_keys='Attachment.ticket_uid')
 
     creator = db.relationship('User', foreign_keys=[created_by])
+
+    approvals = db.relationship('TicketApproval', backref='ticket', lazy='dynamic',
+                                cascade='all, delete-orphan',
+                                foreign_keys='TicketApproval.ticket_uid')
+
+    def is_overdue(self):
+        return bool(self.deadline_at and self.status not in ('resolved', 'closed', 'cancelled')
+                    and self.deadline_at < datetime.utcnow())
 
 
 # ---------------------------------------------------------------------------
@@ -289,3 +313,93 @@ class Attachment(db.Model):
     upload_date = db.Column(db.DateTime, default=datetime.utcnow)
 
     uploader = db.relationship('User', foreign_keys=[uploaded_by])
+
+
+class ApprovalRoute(db.Model):
+    __tablename__ = 'approval_routes'
+    __table_args__ = {'schema': 'sm'}
+
+    route_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    catalog_uid = db.Column(db.String(36), db.ForeignKey('sm.service_catalog.catalog_uid'), nullable=False)
+    route_name = db.Column(db.String(200), nullable=False)
+    is_active = db.Column(db.Boolean, default=True)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+    create_by = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+
+    steps = db.relationship('ApprovalStep', backref='route', lazy='dynamic',
+                            cascade='all, delete-orphan',
+                            foreign_keys='ApprovalStep.route_uid')
+
+
+class ApprovalStep(db.Model):
+    __tablename__ = 'approval_steps'
+    __table_args__ = {'schema': 'sm'}
+
+    step_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    route_uid = db.Column(db.String(36), db.ForeignKey('sm.approval_routes.route_uid'), nullable=False)
+    step_order = db.Column(db.Integer, nullable=False, default=1)
+    step_name = db.Column(db.String(200), nullable=True)
+    approver_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    approver_role = db.Column(db.String(32), nullable=True)
+
+    approver = db.relationship('User', foreign_keys=[approver_uid])
+
+
+class TicketApproval(db.Model):
+    __tablename__ = 'ticket_approvals'
+    __table_args__ = {'schema': 'sm'}
+
+    approval_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    ticket_uid = db.Column(db.String(36), db.ForeignKey('sm.tickets.ticket_uid', ondelete='CASCADE'), nullable=False)
+    step_order = db.Column(db.Integer, nullable=False, default=1)
+    step_name = db.Column(db.String(200), nullable=True)
+    approver_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    status = db.Column(db.String(20), nullable=False, default='pending')
+    comment = db.Column(db.Text, nullable=True)
+    decided_at = db.Column(db.DateTime, nullable=True)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    approver = db.relationship('User', foreign_keys=[approver_uid])
+
+
+class Notification(db.Model):
+    __tablename__ = 'notifications'
+    __table_args__ = {'schema': 'sm'}
+
+    notification_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    user_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+    ticket_uid = db.Column(db.String(36), db.ForeignKey('sm.tickets.ticket_uid'), nullable=True)
+    message = db.Column(db.Text, nullable=False)
+    is_read = db.Column(db.Boolean, default=False)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+    ticket_rel = db.relationship('Ticket', foreign_keys=[ticket_uid])
+
+
+class TicketTemplate(db.Model):
+    __tablename__ = 'ticket_templates'
+    __table_args__ = {'schema': 'sm'}
+
+    template_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    template_name = db.Column(db.String(200), nullable=False)
+    catalog_uid = db.Column(db.String(36), db.ForeignKey('sm.service_catalog.catalog_uid'), nullable=False)
+    summary = db.Column(db.String(500), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    priority = db.Column(db.String(20), nullable=True)
+    is_public = db.Column(db.Boolean, default=False)
+    created_by = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=False)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class AuditLog(db.Model):
+    __tablename__ = 'audit_log'
+    __table_args__ = {'schema': 'sm'}
+
+    audit_uid = db.Column(db.String(36), primary_key=True, default=gen_uuid)
+    user_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
+    action = db.Column(db.String(64), nullable=False)
+    entity_type = db.Column(db.String(64), nullable=True)
+    entity_uid = db.Column(db.String(36), nullable=True)
+    details = db.Column(db.Text, nullable=True)
+    ip_address = db.Column(db.String(64), nullable=True)
+    create_date = db.Column(db.DateTime, default=datetime.utcnow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Werkzeug==3.0.3
 psycopg2-binary
-SQLAlchemy==2.0.30
+SQLAlchemy==2.0.44

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS sm.users (
     title           varchar(255) NULL,
     department      varchar(255) NULL,
     company         varchar(255) NULL,
+    manager_uid     uuid NULL,
+    avatar          varchar(32) DEFAULT 'cat' NULL,
     work_status     varchar(20)  NULL,
     is_vip          bool         DEFAULT false NULL,
     is_deactivated  bool         DEFAULT false NULL,
@@ -112,6 +114,8 @@ CREATE TABLE IF NOT EXISTS sm.service_catalog (
     work_group_uid      uuid NULL REFERENCES sm.work_groups(work_group_uid),
     ticket_type         varchar(100) DEFAULT 'service_request',
     priority            varchar(20)  DEFAULT 'medium',
+    approval_required   bool DEFAULT false NULL,
+    is_active           bool DEFAULT true NULL,
     sla_uid             uuid NULL REFERENCES sm.sla_policies(sla_uid),
     catalog_icon        varchar(64)  DEFAULT 'briefcase',
     catalog_description text NULL,
@@ -135,6 +139,7 @@ CREATE TABLE IF NOT EXISTS sm.tickets (
     performer_uid uuid         NULL     REFERENCES sm.users(user_uid),
     status        varchar(50)  NOT NULL DEFAULT 'new',
     priority      varchar(20)  NULL     DEFAULT 'medium',
+    deadline_at   timestamptz  NULL,
     resolved_at   timestamptz  NULL,
     closed_at     timestamptz  NULL,
     created_at    timestamptz  DEFAULT CURRENT_TIMESTAMP NULL,
@@ -183,6 +188,86 @@ CREATE TABLE IF NOT EXISTS sm.attachments (
     file_size       text NULL,
     uploaded_by     uuid NOT NULL REFERENCES sm.users(user_uid),
     upload_date     timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+);
+
+-- -------------------------------------------------------------
+-- sm.approval_routes
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.approval_routes (
+    route_uid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_name   varchar(200) NOT NULL,
+    catalog_uid  uuid NOT NULL REFERENCES sm.service_catalog(catalog_uid) ON DELETE CASCADE,
+    is_active    bool DEFAULT true NULL,
+    create_date  timestamptz DEFAULT CURRENT_TIMESTAMP NULL,
+    create_by    uuid NOT NULL REFERENCES sm.users(user_uid)
+);
+
+-- -------------------------------------------------------------
+-- sm.approval_steps
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.approval_steps (
+    step_uid       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    route_uid      uuid NOT NULL REFERENCES sm.approval_routes(route_uid) ON DELETE CASCADE,
+    step_order     int4 NOT NULL DEFAULT 1,
+    step_name      varchar(200) NULL,
+    approver_uid   uuid NULL REFERENCES sm.users(user_uid),
+    approver_role  varchar(32) NULL
+);
+
+-- -------------------------------------------------------------
+-- sm.ticket_approvals
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.ticket_approvals (
+    approval_uid  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    ticket_uid    uuid NOT NULL REFERENCES sm.tickets(ticket_uid) ON DELETE CASCADE,
+    step_order    int4 NOT NULL DEFAULT 1,
+    step_name     varchar(200) NULL,
+    approver_uid  uuid NULL REFERENCES sm.users(user_uid),
+    status        varchar(20) NOT NULL DEFAULT 'pending',
+    comment       text NULL,
+    decided_at    timestamptz NULL,
+    create_date   timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+);
+
+-- -------------------------------------------------------------
+-- sm.notifications
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.notifications (
+    notification_uid  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_uid          uuid NOT NULL REFERENCES sm.users(user_uid) ON DELETE CASCADE,
+    message           text NOT NULL,
+    ticket_uid        uuid NULL REFERENCES sm.tickets(ticket_uid) ON DELETE SET NULL,
+    is_read           bool DEFAULT false NULL,
+    create_date       timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+);
+
+-- -------------------------------------------------------------
+-- sm.ticket_templates
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.ticket_templates (
+    template_uid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_name   varchar(200) NOT NULL,
+    catalog_uid     uuid NOT NULL REFERENCES sm.service_catalog(catalog_uid) ON DELETE CASCADE,
+    summary         varchar(500) NOT NULL,
+    description     text NOT NULL,
+    priority        varchar(20) NULL,
+    created_by      uuid NOT NULL REFERENCES sm.users(user_uid),
+    is_public       bool DEFAULT false NULL,
+    create_date     timestamptz DEFAULT CURRENT_TIMESTAMP NULL
+);
+
+-- -------------------------------------------------------------
+-- sm.audit_log
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sm.audit_log (
+    audit_uid      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_uid       uuid NULL REFERENCES sm.users(user_uid) ON DELETE SET NULL,
+    action         varchar(64) NOT NULL,
+    entity_type    varchar(64) NULL,
+    entity_uid     uuid NULL,
+    details        text NULL,
+    ip_address     varchar(64) NULL,
+    create_date    timestamptz DEFAULT CURRENT_TIMESTAMP NULL
 );
 
 -- -------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Introduce ticket approval workflow, user avatars, notifications and audit logging to support approval-required services and better ticket lifecycle tracking.
- Provide lightweight DB migration and compatibility code so existing installations with differing UUID column types can be upgraded without manual SQL fixes.
- Add SLA/deadline handling to estimate ticket due dates from catalog SLA or priority.

### Description
- Added new ORM models `ApprovalRoute`, `ApprovalStep`, `TicketApproval`, `Notification`, `TicketTemplate`, and `AuditLog`, and added `manager_uid` and `avatar` fields on `User`, `approval_required`/`is_active` on `ServiceCatalog`, and `deadline_at` on `Ticket` in `models.py`.
- Implemented utility functions in `db_functions.py` including `compute_deadline`, `notify`, `notify_ticket_update`, `audit`, `create_approval_chain`, and `process_approval_decision`, and extended `create_user_db` to accept `manager_uid` and `avatar`.
- Enhanced DB initialization in `app.py` to catch `SQLAlchemyError`, run explicit `CREATE TABLE IF NOT EXISTS` statements for new tables, and perform lightweight `ALTER TABLE` migrations for added columns.
- Updated schema SQL `sql/01_schema.sql` to create the new tables/columns and added a `.gitignore` and bumped `SQLAlchemy` in `requirements.txt` to `2.0.44`.

### Testing
- Ran the project's automated test suite via `pytest`, which completed without failures.
- Executed the DB initialization path by running the Flask CLI `flask init-db` against a test database, and the explicit `CREATE TABLE`/`ALTER TABLE` statements executed successfully.
- No automated tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d134b6b94483238cc9a4de498edc72)