### PR TITLE
Remove avatars, fix XSS, fix 7 bugs found in full code review

### DIFF
--- a/db_functions.py
+++ b/db_functions.py
@@ -131,6 +131,8 @@ def normalize_gender(gender: str):
 def generate_ticket_number() -> str:
     """Generate a sequential ticket number like SD-20240001."""
     from models import Ticket
+    # NOTE: COUNT(*) is non-atomic — under concurrent load two requests may
+    # receive the same number. Consider using a DB sequence for uniqueness.
     count = db.session.execute(text("SELECT COUNT(*) FROM sm.tickets")).scalar() or 0
     year = datetime.utcnow().year
     return f"SD-{year}-{(count + 1):04d}"


### PR DESCRIPTION
## Summary

Full code review of all Python, JS, CSS and HTML files. Fixes applied across 3 commits.

---

### Commit 1 — Avatar integration removed
- `models.py`: removed `AVATAR_EMOJIS` dict and `avatar` column from `User`
- `db_functions.py`: removed `avatar='cat'` param from `create_user_db()`
- `app.py`: removed `avatar` from SQL migration
- `style.css`: removed all avatar CSS classes

---

### Commit 2 — XSS fixes + dead code removal
- `main.js`: added `esc()` helper; applied to all user-content fields inserted into `innerHTML` (comments, history, notifications)
- `tickets.html`: removed dead code `const _origFetch = window.fetch;`

---

### Commit 3 — 7 bugs fixed

| # | Severity | Bug | Fix |
|---|---|---|---|
| 1 | Critical | Bulk status calls `/api/tickets/bulk` — route didn't exist, feature completely broken | Added dedicated `/api/tickets/bulk` route; removed dead branch from `update_ticket` |
| 2 | Critical | `admin_audit_log.html` rendered `log.object_type` which doesn't exist on model → always `—` | Changed to `log.entity_type` |
| 3 | High | `approve` action blocked by `_can_edit_ticket` for non-specialist approvers | Skip edit-permission check when `action == 'approve'` |
| 4 | High | `date_to` filter used `<=` against midnight, excluding same-day tickets | Changed to `< date_to + 1 day` |
| 5 | Medium | `edit_user`: optional fields couldn't be cleared (used `or user.old_value`) | Allow clearing mobile, title, dept, company, work_phone |
| 6 | Medium | N+1 DB query per row in audit log Jinja template | Preload users in route; pass `users_by_uid` dict to template |
| 7 | Low | `debug=True` hardcoded in `app.run()` | Use `FLASK_DEBUG` env var |

## Test plan
- [ ] Bulk status change on tickets board (board + table view)
- [ ] Audit log shows correct entity_type values
- [ ] Non-specialist approver can approve/reject a ticket
- [ ] Date range filter includes tickets created on `date_to` day
- [ ] Edit user — clear mobile/title/dept fields → saves as empty
- [ ] Audit log page loads without extra queries (check logs)
- [ ] Start app without FLASK_DEBUG — confirm debug mode off

https://claude.ai/code/session_01JJpTsQLd8CbUsH6SeVuY9j