### PR TITLE
Remove avatar integration, fix XSS, fix 7 bugs (full code review)

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,8 +256,7 @@ def init_db():
     # Lightweight compatibility migration for older databases.
     db.session.execute(text("""
         ALTER TABLE IF EXISTS sm.users
-            ADD COLUMN IF NOT EXISTS manager_uid uuid NULL,
-            ADD COLUMN IF NOT EXISTS avatar varchar(32) NULL DEFAULT 'cat'
+            ADD COLUMN IF NOT EXISTS manager_uid uuid NULL
     """))
     db.session.execute(text("""
         ALTER TABLE IF EXISTS sm.service_catalog

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ Flask + PostgreSQL + SQLAlchemy
 """
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash
 from werkzeug.utils import secure_filename
 from flask import (Flask, render_template, request, redirect, jsonify,
@@ -638,7 +638,9 @@ def tickets_board():
             pass
     if fd_to:
         try:
-            query = query.filter(Ticket.created_at <= datetime.strptime(fd_to, '%Y-%m-%d'))
+            query = query.filter(
+                Ticket.created_at < datetime.strptime(fd_to, '%Y-%m-%d') + timedelta(days=1)
+            )
         except ValueError:
             pass
 
@@ -852,11 +854,13 @@ def get_ticket(ticket_uid):
 @login_required
 def update_ticket(ticket_uid):
     ticket = Ticket.query.get_or_404(ticket_uid)
-    if not _can_edit_ticket(ticket):
-        return jsonify({'error': 'Доступ запрещён'}), 403
-
     data   = request.get_json() or {}
     action = data.get('action')
+
+    # Approve only needs the user to be a pending approver — checked inside the branch.
+    # All other mutating actions require edit permission.
+    if action != 'approve' and not _can_edit_ticket(ticket):
+        return jsonify({'error': 'Доступ запрещён'}), 403
     now    = datetime.utcnow()
 
     if action == 'take':
@@ -936,26 +940,40 @@ def update_ticket(ticket_uid):
         db.session.commit()
         return jsonify({'success': True, 'deleted': True})
 
-    elif action == 'bulk_status':
-        if not is_specialist():
-            return jsonify({'error': 'Доступ запрещён'}), 403
-        uids       = data.get('ticket_uids', [])
-        new_status = data.get('status')
-        valid = ['in_progress', 'on_hold', 'resolved', 'closed', 'cancelled']
-        if new_status not in valid:
-            return jsonify({'error': 'Недопустимый статус'}), 400
-        Ticket.query.filter(Ticket.ticket_uid.in_(uids)).update(
-            {'status': new_status, 'updated_at': now, 'updated_by': current_user.user_uid},
-            synchronize_session=False,
-        )
-        db.session.commit()
-        return jsonify({'success': True})
-
     else:
         return jsonify({'error': 'Неизвестное действие'}), 400
 
     ticket.updated_at = now
     ticket.updated_by = current_user.user_uid
+    db.session.commit()
+    return jsonify({'success': True})
+
+
+# ============================================================
+# TICKET API — BULK UPDATE
+# ============================================================
+
+@app.route('/api/tickets/bulk', methods=['POST'])
+@login_required
+def bulk_update_tickets():
+    if not is_specialist():
+        return jsonify({'error': 'Доступ запрещён'}), 403
+    data       = request.get_json() or {}
+    action     = data.get('action')
+    new_status = data.get('status')
+    uids       = data.get('ticket_uids', [])
+    valid_statuses = ['in_progress', 'on_hold', 'resolved', 'closed', 'cancelled']
+    if action != 'bulk_status':
+        return jsonify({'error': 'Неизвестное действие'}), 400
+    if new_status not in valid_statuses:
+        return jsonify({'error': 'Недопустимый статус'}), 400
+    if not uids:
+        return jsonify({'error': 'Нет заявок для обновления'}), 400
+    now = datetime.utcnow()
+    Ticket.query.filter(Ticket.ticket_uid.in_(uids)).update(
+        {'status': new_status, 'updated_at': now, 'updated_by': current_user.user_uid},
+        synchronize_session=False,
+    )
     db.session.commit()
     return jsonify({'success': True})
 
@@ -1232,15 +1250,17 @@ def edit_user(user_uid):
     ).order_by(User.last_name).all()
 
     if request.method == 'POST':
-        user.first_name     = request.form.get('first_name', '').strip() or user.first_name
-        user.last_name      = request.form.get('last_name', '').strip() or user.last_name
-        user.middel_name    = request.form.get('middle_name', '').strip() or user.middel_name
-        user.email          = request.form.get('email', '').strip() or user.email
-        user.mobile         = format_mobile(request.form.get('mobile', '')) or user.mobile
-        user.work_phone     = request.form.get('work_phone', '').strip() or user.work_phone
-        user.title          = request.form.get('title', '').strip() or user.title
-        user.department     = request.form.get('department', '').strip() or user.department
-        user.company        = request.form.get('company', '').strip() or user.company
+        # Required fields: keep old value only if form sends empty string
+        user.first_name  = request.form.get('first_name', '').strip() or user.first_name
+        user.last_name   = request.form.get('last_name', '').strip() or user.last_name
+        user.email       = request.form.get('email', '').strip() or user.email
+        # Optional fields: allow clearing by setting to None when blank
+        user.middel_name = request.form.get('middle_name', '').strip() or None
+        user.mobile      = format_mobile(request.form.get('mobile', '').strip()) or None
+        user.work_phone  = request.form.get('work_phone', '').strip() or None
+        user.title       = request.form.get('title', '').strip() or None
+        user.department  = request.form.get('department', '').strip() or None
+        user.company     = request.form.get('company', '').strip() or None
         user.manager_uid    = request.form.get('manager_uid') or None
         user.is_deactivated = 'is_deactivated' in request.form
         user.update_date    = datetime.utcnow()
@@ -1437,7 +1457,9 @@ def admin_audit_log():
     page = request.args.get('page', 1, type=int)
     logs = AuditLog.query.order_by(AuditLog.create_date.desc()).paginate(
         page=page, per_page=50, error_out=False)
-    return render_template('admin_audit_log.html', logs=logs)
+    uids = {log.user_uid for log in logs.items if log.user_uid}
+    users_by_uid = {u.user_uid: u for u in User.query.filter(User.user_uid.in_(uids)).all()}
+    return render_template('admin_audit_log.html', logs=logs, users_by_uid=users_by_uid)
 
 
 # ============================================================
@@ -1445,4 +1467,5 @@ def admin_audit_log():
 # ============================================================
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug = os.environ.get('FLASK_DEBUG', 'false').lower() == 'true'
+    app.run(debug=debug, host='0.0.0.0', port=5000)

--- a/db_functions.py
+++ b/db_functions.py
@@ -144,7 +144,7 @@ def generate_ticket_number() -> str:
 def create_user_db(last_name, first_name, middle_name, email, mobile,
                    work_phone, gender, title, department, company,
                    role='user', work_group_uid=None, manager_uid=None,
-                   creator_uid=None, avatar='cat') -> tuple:
+                   creator_uid=None) -> tuple:
     """
     Creates a user.  Tries sm.create_user() first; falls back to manual INSERT.
 
@@ -173,7 +173,6 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
                 _ensure_role(user.user_uid, role, creator_uid)
                 _ensure_work_group(user.user_uid, work_group_uid)
                 user.manager_uid = manager_uid
-                user.avatar = avatar or user.avatar or 'cat'
                 db.session.commit()
                 return user_name, temp_password
 
@@ -201,7 +200,6 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
         department=department or None,
         company=company or None,
         manager_uid=manager_uid,
-        avatar=avatar or 'cat',
         create_by=sys_uid,
         update_by=sys_uid,
     )

--- a/models.py
+++ b/models.py
@@ -4,11 +4,6 @@ from flask_login import UserMixin
 from datetime import datetime
 
 db = SQLAlchemy()
-AVATAR_EMOJIS = {
-    'cat': '🐱', 'dog': '🐶', 'fox': '🦊', 'bear': '🐻', 'penguin': '🐧',
-    'owl': '🦉', 'tiger': '🐯', 'rabbit': '🐰', 'wolf': '🐺', 'panda': '🐼',
-    'frog': '🐸', 'lion': '🦁', 'koala': '🐨', 'duck': '🦆', 'dragon': '🐲',
-}
 
 
 def gen_uuid():
@@ -35,7 +30,6 @@ class User(UserMixin, db.Model):
     department = db.Column(db.String(255), nullable=True)
     company = db.Column(db.String(255), nullable=True)
     manager_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
-    avatar = db.Column(db.String(32), nullable=False, default='cat')
     work_status = db.Column(db.String(20), nullable=True)
     is_vip = db.Column(db.Boolean, default=False)
     is_deactivated = db.Column(db.Boolean, default=False)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,18 +69,6 @@ a:hover { color: var(--accent-hover); }
 button { cursor: pointer; font-family: inherit; }
 input, select, textarea { font-family: inherit; }
 
-/* Avatars removed by request */
-.nav-avatar,
-.td-avatar,
-.card-avatar,
-.profile-avatar-section,
-.user-profile-avatar,
-.avatar-picker,
-.avatar-grid,
-.avatar-option {
-  display: none !important;
-}
-
 /* =========================================================
    NAVBAR
    ========================================================= */
@@ -196,7 +184,6 @@ input, select, textarea { font-family: inherit; }
 }
 .nav-profile:hover { background: var(--bg-hover); color: var(--text); }
 .nav-profile.active { color: var(--text); }
-.nav-avatar { font-size: 18px; }
 .nav-logout {
   display: flex;
   align-items: center;
@@ -687,7 +674,6 @@ input, select, textarea { font-family: inherit; }
 .row-deactivated { opacity: .5; }
 .row-overdue td { background: rgba(239,68,68,.04); }
 .table-empty { text-align: center; color: var(--text-muted); padding: 30px; }
-.td-avatar { font-size: 20px; text-align: center; width: 40px; }
 .td-mono { font-family: monospace; font-size: 12px; }
 .td-actions { display: flex; gap: 4px; align-items: center; }
 .td-date { white-space: nowrap; color: var(--text-muted); font-size: 12px; }
@@ -1024,13 +1010,6 @@ input, select, textarea { font-family: inherit; }
   gap: 6px;
   flex-wrap: wrap;
 }
-.card-avatar {
-  font-size: 16px;
-  text-decoration: none;
-  transition: transform .15s;
-  display: inline-block;
-}
-.card-avatar:hover { transform: scale(1.2); }
 .card-unassigned { font-size: 11px; color: var(--text-dim); }
 .card-deadline {
   display: inline-flex;
@@ -1312,8 +1291,6 @@ input, select, textarea { font-family: inherit; }
   gap: 16px;
   align-self: start;
 }
-.profile-avatar-section { display: flex; flex-direction: column; align-items: center; gap: 8px; }
-.profile-avatar-big { font-size: 56px; line-height: 1; }
 .profile-name { font-size: 18px; font-weight: 700; text-align: center; }
 .profile-role { text-align: center; font-size: 12px; color: var(--text-muted); }
 .profile-info-grid { display: flex; flex-direction: column; gap: 8px; }
@@ -1341,34 +1318,6 @@ input, select, textarea { font-family: inherit; }
 .profile-pwd-section svg { width: 13px; height: 13px; }
 .profile-tickets { }
 
-/* Avatar picker */
-.avatar-picker {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 14px;
-}
-.avatar-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 6px;
-  margin-bottom: 10px;
-}
-.avatar-option {
-  font-size: 22px;
-  padding: 6px;
-  border-radius: var(--radius-sm);
-  border: 2px solid transparent;
-  background: none;
-  cursor: pointer;
-  transition: all .12s;
-  line-height: 1;
-}
-.avatar-option:hover { background: var(--bg-hover); border-color: var(--border); }
-.avatar-option.selected { border-color: var(--accent); background: var(--accent-dim); }
-.avatar-picker-actions { display: flex; justify-content: flex-end; gap: 6px; }
-.mb-2 { margin-bottom: 12px; }
-
 /* Public profile */
 .user-profile-card {
   padding: 28px;
@@ -1380,7 +1329,6 @@ input, select, textarea { font-family: inherit; }
   gap: 16px;
   margin-bottom: 20px;
 }
-.user-profile-avatar { font-size: 52px; line-height: 1; }
 .user-profile-info h2 { font-size: 20px; font-weight: 700; }
 .user-role-badge { display: inline-block; margin-top: 4px; }
 .user-title { font-size: 13px; color: var(--text-muted); margin-top: 4px; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,6 +4,17 @@
 
 'use strict';
 
+// ---- HTML escaping to prevent XSS when inserting user content into innerHTML ----
+function esc(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // ---- Toast notifications ----
 function showToast(msg, type = 'info', duration = 3500) {
   let container = document.getElementById('toastContainer');
@@ -127,10 +138,10 @@ function renderNotifications(data) {
     return;
   }
   list.innerHTML = data.items.map(n => `
-    <div class="notif-item" onclick="notifClick('${n.uid}', '${n.ticket_uid || ''}')">
-      <div class="notif-msg">${n.message}</div>
-      ${n.ticket_number ? `<div class="notif-num">${n.ticket_number}</div>` : ''}
-      <div class="notif-date">${n.created_at}</div>
+    <div class="notif-item" onclick="notifClick('${esc(n.uid)}', '${esc(n.ticket_uid || '')}')">
+      <div class="notif-msg">${esc(n.message)}</div>
+      ${n.ticket_number ? `<div class="notif-num">${esc(n.ticket_number)}</div>` : ''}
+      <div class="notif-date">${esc(n.created_at)}</div>
     </div>
   `).join('');
 }
@@ -343,11 +354,11 @@ function renderTicketModal(t) {
   document.getElementById('modalHistory').innerHTML = t.history.length
     ? t.history.map(h => `
       <div class="history-item">
-        <span class="history-field">${h.field}</span>
+        <span class="history-field">${esc(h.field)}</span>
         <span class="history-arrow">→</span>
-        <span class="history-new">${h.new || '—'}</span>
-        <span class="history-by">${h.by}</span>
-        <span class="history-date">${h.date}</span>
+        <span class="history-new">${esc(h.new) || '—'}</span>
+        <span class="history-by">${esc(h.by)}</span>
+        <span class="history-date">${esc(h.date)}</span>
       </div>
     `).join('')
     : '<div class="history-empty">Нет истории</div>';
@@ -362,13 +373,13 @@ function renderComments(comments) {
   el.innerHTML = comments.map(c => `
     <div class="comment ${c.is_internal ? 'comment-internal' : ''}">
       <div class="comment-header">
-        <a href="/user/${c.author_uid}" class="comment-author">
-          ${c.author}
+        <a href="/user/${esc(c.author_uid)}" class="comment-author">
+          ${esc(c.author)}
         </a>
         ${c.is_internal ? '<span class="comment-internal-badge">Внутренний</span>' : ''}
-        <span class="comment-date">${c.created_at}</span>
+        <span class="comment-date">${esc(c.created_at)}</span>
       </div>
-      <div class="comment-text">${c.text.replace(/\n/g, '<br>')}</div>
+      <div class="comment-text">${esc(c.text).replace(/\n/g, '<br>')}</div>
     </div>
   `).join('');
 }

--- a/templates/admin_audit_log.html
+++ b/templates/admin_audit_log.html
@@ -19,7 +19,7 @@
       </thead>
       <tbody>
         {% for log in logs.items %}
-        {% set u = User.query.get(log.user_uid) %}
+        {% set u = users_by_uid.get(log.user_uid) %}
         <tr>
           <td class="td-date">{{ log.create_date|datefmt }}</td>
           <td>
@@ -30,7 +30,7 @@
             {% else %}—{% endif %}
           </td>
           <td><span class="tag">{{ log.action }}</span></td>
-          <td>{{ log.object_type or '—' }}</td>
+          <td>{{ log.entity_type or '—' }}</td>
           <td>{{ log.details or '—' }}</td>
           <td class="td-mono text-muted">{{ log.ip_address or '—' }}</td>
         </tr>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -356,8 +356,5 @@ document.getElementById('bulkApply').onclick = async function() {
     else showToast(d.error || 'Ошибка', 'error');
   } catch(e) { showToast('Ошибка сети', 'error'); }
 };
-
-// Fix: bulk endpoint
-const _origFetch = window.fetch;
 </script>
 {% endblock %}


### PR DESCRIPTION
## What happened
PR #9 was merged before the main commits landed. This PR contains the 2 commits that were missed.

---

## Commit 1 — Remove avatar integration + fix XSS

**Avatar removal:**
- `models.py`: removed `AVATAR_EMOJIS` dict and `avatar` column from `User`
- `db_functions.py`: removed `avatar='cat'` param from `create_user_db()`
- `app.py`: removed `avatar` column from SQL migration
- `style.css`: removed all avatar CSS classes (`.nav-avatar`, `.td-avatar`, `.card-avatar`, `.avatar-picker`, `.avatar-grid`, `.avatar-option`, `.profile-avatar-*`, `.user-profile-avatar`)

**XSS fixes (`main.js`):**
- Added `esc()` HTML-escape helper
- Applied to all user-supplied content inserted into `innerHTML`: comment text, author names, history fields, notification messages

**Dead code removed (`tickets.html`):**
- Removed `const _origFetch = window.fetch;` leftover stub

---

## Commit 2 — Fix 7 bugs found in full code review

| # | Severity | Bug | Fix |
|---|---|---|---|
| 1 | Critical | Bulk status JS called `/api/tickets/bulk` — route didn't exist, feature broken | Added `/api/tickets/bulk` route; removed dead `bulk_status` branch from `update_ticket` |
| 2 | Critical | `admin_audit_log.html`: `log.object_type` doesn't exist on model → always `—` | Changed to `log.entity_type` |
| 3 | High | `approve` action blocked by `_can_edit_ticket` for non-specialist approvers | Skip edit-permission check when `action == 'approve'` |
| 4 | High | `date_to` filter used `<=` midnight — tickets created that day were excluded | Changed to `< date_to + 1 day` |
| 5 | Medium | `edit_user`: optional fields couldn't be cleared (`or user.old_value` kept old data) | Allow clearing mobile, title, dept, company, work_phone |
| 6 | Medium | N+1 DB query per row in audit log Jinja template | Preload users in route; pass `users_by_uid` dict to template |
| 7 | Low | `debug=True` hardcoded in `app.run()` | Controlled via `FLASK_DEBUG` env var |

## Test plan
- [ ] Bulk status change on tickets board works
- [ ] Audit log shows correct `entity_type` values
- [ ] Non-specialist approver can approve/reject
- [ ] Date range filter includes tickets on `date_to` day
- [ ] Edit user — clear mobile/title/dept → saves as empty
- [ ] Comment with `<script>` renders as escaped text
- [ ] No avatar field in DB or UI

https://claude.ai/code/session_01JJpTsQLd8CbUsH6SeVuY9j