### PR TITLE
Refactor DB helpers and add simple form-based ticket workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -793,6 +793,41 @@ def tickets_board():
 # TICKET API — CREATE
 # ============================================================
 
+@app.route('/tickets/new', methods=['POST'])
+@login_required
+def create_ticket_form():
+    catalog_uid = request.form.get('catalog_uid', '').strip()
+    summary = request.form.get('summary', '').strip()
+    description = request.form.get('description', '').strip()
+    if not catalog_uid or not summary or not description:
+        flash('Заполните все поля', 'error')
+        return redirect('/')
+    catalog = ServiceCatalog.query.get(catalog_uid)
+    if not catalog or not catalog.is_active or catalog.catalog_type == 'category':
+        flash('Услуга не найдена', 'error')
+        return redirect('/')
+
+    ticket = Ticket(
+        ticket_number=generate_ticket_number(),
+        catalog_uid=catalog_uid,
+        summary=summary,
+        description=description,
+        requester_uid=current_user.user_uid,
+        recipient_uid=current_user.user_uid,
+        status='new',
+        priority=catalog.priority or 'medium',
+        deadline_at=compute_deadline(catalog),
+        created_by=current_user.user_uid,
+        updated_by=current_user.user_uid,
+    )
+    db.session.add(ticket)
+    db.session.flush()
+    add_ticket_history(ticket.ticket_uid, 'status', None, 'new', current_user.user_uid)
+    db.session.commit()
+    flash(f'Заявка {ticket.ticket_number} создана', 'success')
+    return redirect(f'/ticket/{ticket.ticket_uid}')
+
+
 @app.route('/api/tickets', methods=['POST'])
 @login_required
 def create_ticket():
@@ -850,6 +885,23 @@ def create_ticket():
 # ============================================================
 # TICKET API — GET
 # ============================================================
+
+@app.route('/ticket/<ticket_uid>')
+@login_required
+def ticket_detail(ticket_uid):
+    ticket = Ticket.query.get_or_404(ticket_uid)
+    if not _can_view_ticket(ticket):
+        flash('Доступ запрещён', 'error')
+        return redirect('/')
+    specialists = User.query.join(UserRole).filter(
+        UserRole.role.in_(['specialist', 'manager', 'admin'])
+    ).all() if current_user.role in ('admin', 'manager') else []
+    comments = ticket.param_values.filter(
+        TicketParamValue.param_type == 'comment'
+    ).order_by(TicketParamValue.create_date).all()
+    return render_template('ticket_detail.html',
+                           ticket=ticket, specialists=specialists, comments=comments)
+
 
 @app.route('/api/tickets/<ticket_uid>', methods=['GET'])
 @login_required
@@ -938,6 +990,31 @@ def get_ticket(ticket_uid):
 # ============================================================
 # TICKET API — UPDATE
 # ============================================================
+
+@app.route('/ticket/<ticket_uid>/update', methods=['POST'])
+@login_required
+def update_ticket_form(ticket_uid):
+    ticket = Ticket.query.get_or_404(ticket_uid)
+    if not _can_edit_ticket(ticket):
+        flash('Доступ запрещён', 'error')
+        return redirect(f'/ticket/{ticket_uid}')
+    new_status = request.form.get('status')
+    new_performer = request.form.get('performer_uid') or None
+    now = datetime.utcnow()
+    if new_status and new_status != ticket.status:
+        add_ticket_history(ticket_uid, 'status', ticket.status, new_status, current_user.user_uid)
+        ticket.status = new_status
+        if new_status == 'resolved':
+            ticket.resolved_at = now
+    if 'performer_uid' in request.form and new_performer != ticket.performer_uid:
+        add_ticket_history(ticket_uid, 'performer', ticket.performer_uid, new_performer, current_user.user_uid)
+        ticket.performer_uid = new_performer
+    ticket.updated_at = now
+    ticket.updated_by = current_user.user_uid
+    db.session.commit()
+    flash('Заявка обновлена', 'success')
+    return redirect(f'/ticket/{ticket_uid}')
+
 
 @app.route('/api/tickets/<ticket_uid>/update', methods=['POST'])
 @login_required
@@ -1372,14 +1449,22 @@ def edit_user(user_uid):
 @login_required
 def delete_user(user_uid):
     if current_user.role != 'admin':
-        return jsonify({'error': 'Доступ запрещён'}), 403
+        if request.is_json:
+            return jsonify({'error': 'Доступ запрещён'}), 403
+        return 'Доступ запрещён', 403
     user = User.query.get_or_404(user_uid)
     if user.user_uid == current_user.user_uid:
-        return jsonify({'error': 'Нельзя деактивировать себя'}), 400
+        if request.is_json:
+            return jsonify({'error': 'Нельзя деактивировать себя'}), 400
+        flash('Нельзя деактивировать себя', 'error')
+        return redirect('/admin/users')
     user.is_deactivated = True
     user.update_date = datetime.utcnow()
     db.session.commit()
-    return jsonify({'success': True})
+    if request.is_json:
+        return jsonify({'success': True})
+    flash('Пользователь деактивирован', 'success')
+    return redirect('/admin/users')
 
 
 @app.route('/admin/reset-password/<user_uid>', methods=['POST'])
@@ -1497,27 +1582,36 @@ def toggle_category(cat_uid):
 @login_required
 def delete_category(cat_uid):
     if current_user.role != 'admin':
-        return jsonify({'error': 'Доступ запрещён'}), 403
+        if request.is_json:
+            return jsonify({'error': 'Доступ запрещён'}), 403
+        return 'Доступ запрещён', 403
     cat = ServiceCatalog.query.get_or_404(cat_uid)
     ticket_count = Ticket.query.filter_by(catalog_uid=cat_uid).count()
     if ticket_count > 0:
-        return jsonify({
-            'error': f'Нельзя удалить: к этой категории привязано {ticket_count} заявок. '
-                     f'Сначала скройте её (глазик), чтобы запретить новые заявки.'
-        }), 400
+        msg = (f'Нельзя удалить: к этой категории привязано {ticket_count} заявок. '
+               f'Сначала скройте её (глазик), чтобы запретить новые заявки.')
+        if request.is_json:
+            return jsonify({'error': msg}), 400
+        flash(msg, 'error')
+        return redirect('/admin/categories')
     # Also delete child services if this is a top-level category
     for child in cat.children.all():
         if Ticket.query.filter_by(catalog_uid=child.catalog_uid).count() == 0:
             db.session.delete(child)
         else:
-            return jsonify({
-                'error': f'Нельзя удалить: дочерняя услуга «{child.catalog_name}» имеет привязанные заявки.'
-            }), 400
+            msg = f'Нельзя удалить: дочерняя услуга «{child.catalog_name}» имеет привязанные заявки.'
+            if request.is_json:
+                return jsonify({'error': msg}), 400
+            flash(msg, 'error')
+            return redirect('/admin/categories')
     audit(current_user.user_uid, 'delete_category', 'service_catalog', cat_uid,
           f'Удалена категория {cat.catalog_name}', request.remote_addr)
     db.session.delete(cat)
     db.session.commit()
-    return jsonify({'success': True})
+    if request.is_json:
+        return jsonify({'success': True})
+    flash('Категория деактивирована/удалена', 'success')
+    return redirect('/admin/categories')
 
 
 # ============================================================
@@ -1537,33 +1631,52 @@ def admin_work_groups():
 @login_required
 def create_work_group():
     if current_user.role != 'admin':
-        return jsonify({'error': 'Доступ запрещён'}), 403
-    data = request.get_json() or {}
+        if request.is_json:
+            return jsonify({'error': 'Доступ запрещён'}), 403
+        return 'Доступ запрещён', 403
+    data = request.get_json() if request.is_json else request.form
     name = (data.get('group_name') or '').strip()
     desc = (data.get('group_description') or '').strip() or None
     if not name:
-        return jsonify({'error': 'Название обязательно'}), 400
+        if request.is_json:
+            return jsonify({'error': 'Название обязательно'}), 400
+        flash('Название обязательно', 'error')
+        return redirect('/admin/work-groups')
     if WorkGroup.query.filter_by(group_name=name).first():
-        return jsonify({'error': 'Группа уже существует'}), 400
+        if request.is_json:
+            return jsonify({'error': 'Группа уже существует'}), 400
+        flash('Группа уже существует', 'error')
+        return redirect('/admin/work-groups')
     wg = WorkGroup(group_name=name, group_description=desc, create_by=current_user.user_uid)
     db.session.add(wg)
     db.session.commit()
-    return jsonify({'success': True, 'work_group_uid': wg.work_group_uid})
+    if request.is_json:
+        return jsonify({'success': True, 'work_group_uid': wg.work_group_uid})
+    flash('Рабочая группа создана', 'success')
+    return redirect('/admin/work-groups')
 
 
 @app.route('/admin/delete-work-group/<wg_uid>', methods=['POST'])
 @login_required
 def delete_work_group(wg_uid):
     if current_user.role != 'admin':
-        return jsonify({'error': 'Доступ запрещён'}), 403
+        if request.is_json:
+            return jsonify({'error': 'Доступ запрещён'}), 403
+        return 'Доступ запрещён', 403
     wg = WorkGroup.query.get_or_404(wg_uid)
     has_catalog = ServiceCatalog.query.filter_by(work_group_uid=wg_uid).first()
     if has_catalog:
-        return jsonify({'error': 'Нельзя удалить группу: есть связанные услуги'}), 400
+        if request.is_json:
+            return jsonify({'error': 'Нельзя удалить группу: есть связанные услуги'}), 400
+        flash('Нельзя удалить группу: есть связанные услуги', 'error')
+        return redirect('/admin/work-groups')
     UserWorkGroup.query.filter_by(work_group_uid=wg_uid).delete()
     db.session.delete(wg)
     db.session.commit()
-    return jsonify({'success': True})
+    if request.is_json:
+        return jsonify({'success': True})
+    flash('Рабочая группа удалена', 'success')
+    return redirect('/admin/work-groups')
 
 
 # ============================================================

--- a/models.py
+++ b/models.py
@@ -413,7 +413,7 @@ import re
 import random
 import string
 from datetime import timedelta
-from sqlalchemy import text
+from sqlalchemy import text, func
 from werkzeug.security import generate_password_hash, check_password_hash
 
 _RUS = list('АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЫЭЮЯЬЪ')
@@ -438,21 +438,6 @@ def translit(text_ru: str) -> str:
 # LOGIN GENERATION  (mirrors sm.generate_login)
 # ---------------------------------------------------------------------------
 def generate_login(last_name: str, first_name: str, middle_name: str = None) -> str:
-    """
-    Try to call sm.generate_login() in Postgres first.
-    Falls back to Python implementation if the function is not available.
-    """
-    try:
-        row = db.session.execute(
-            text("SELECT sm.generate_login(:ln, :fn, :mn)"),
-            {'ln': last_name, 'fn': first_name, 'mn': middle_name}
-        ).scalar()
-        if row and not row.startswith('ERROR'):
-            return row
-    except Exception:
-        db.session.rollback()
-
-    # Python fallback
     base_ln = translit(last_name)[:8]
     base_fn = translit(first_name)[:1]
     base_mn = translit(middle_name)[:1] if middle_name else ''
@@ -469,17 +454,7 @@ def generate_login(last_name: str, first_name: str, middle_name: str = None) -> 
 # PASSWORD GENERATION  (mirrors sm.generate_password)
 # ---------------------------------------------------------------------------
 def generate_password() -> str:
-    """
-    Try sm.generate_password() first; fall back to Python.
-    """
-    try:
-        row = db.session.execute(text("SELECT sm.generate_password()")).scalar()
-        if row:
-            return row
-    except Exception:
-        db.session.rollback()
-
-    # Python fallback: guaranteed to have upper, lower, digit, special
+    """Generate a strong temporary password."""
     chars = string.ascii_letters + string.digits + '!@#$%&*'
     parts = [
         random.choice(string.ascii_uppercase),
@@ -524,8 +499,7 @@ def normalize_gender(gender: str):
 # ---------------------------------------------------------------------------
 def generate_ticket_number() -> str:
     """Generate a sequential ticket number like SD-20240001."""
-    from models import Ticket
-    count = db.session.execute(text("SELECT COUNT(*) FROM sm.tickets")).scalar() or 0
+    count = db.session.query(func.count(Ticket.ticket_uid)).scalar() or 0
     year = datetime.utcnow().year
     return f"SD-{year}-{(count + 1):04d}"
 
@@ -538,43 +512,11 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
                    role='user', work_group_uid=None, manager_uid=None,
                    creator_uid=None, avatar='cat') -> tuple:
     """
-    Creates a user.  Tries sm.create_user() first; falls back to manual INSERT.
+    Creates a user.
 
     Returns (user_name, temp_password).
     """
     temp_password = generate_password()
-
-    try:
-        # Try the stored procedure
-        row = db.session.execute(
-            text("SELECT sm.create_user(:ln,:fn,:mn,:email,:mob,:wp,:gen,:title,:dept,:comp)"),
-            {
-                'ln': last_name, 'fn': first_name, 'mn': middle_name,
-                'email': email, 'mob': mobile, 'wp': work_phone,
-                'gen': gender, 'title': title, 'dept': department, 'comp': company,
-            }
-        ).scalar()
-
-        if row and not str(row).startswith('ERROR'):
-            # sm.create_user returned the login and already inserted into sm.passwords
-            user_name = row
-            user = User.query.filter_by(user_name=user_name).first()
-            if user:
-                # Overwrite the Postgres-generated hash with Werkzeug hash
-                _set_password_hash(user.user_uid, temp_password)
-                _ensure_role(user.user_uid, role, creator_uid)
-                _ensure_work_group(user.user_uid, work_group_uid)
-                user.manager_uid = manager_uid
-                user.avatar = avatar or user.avatar or 'cat'
-                db.session.commit()
-                return user_name, temp_password
-
-    except Exception as e:
-        db.session.rollback()
-        # Fall through to Python path
-        print(f"[db_functions] sm.create_user failed ({e}), using Python fallback")
-
-    # ---- Python fallback ----
     user_name = generate_login(last_name, first_name, middle_name)
     uid = gen_uuid()
     sys_uid = creator_uid or uid   # self-reference for system bootstrap
@@ -614,7 +556,6 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
 def reset_password_db(user_name: str):
     """
     Generates a new temp password and stores its Werkzeug hash.
-    Tries sm.reset_password() first; falls back to Python.
     Returns the plain-text temporary password.
     """
     user = User.query.filter_by(user_name=user_name).first()
@@ -622,16 +563,6 @@ def reset_password_db(user_name: str):
         return None
 
     temp_password = generate_password()
-
-    try:
-        db.session.execute(
-            text("SELECT sm.reset_password(:uname)"),
-            {'uname': user_name}
-        )
-        # The PG function stores a bcrypt hash — but we need Werkzeug hash for Flask.
-        # Overwrite with Werkzeug hash so check_password_hash() works.
-    except Exception:
-        db.session.rollback()
 
     _set_password_hash(user.user_uid, temp_password)
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,56 +1,9 @@
-function showToast(message) {
-  alert(message);
-}
-
-async function postJSON(url, body) {
-  const r = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body || {})
-  });
-  return r.json();
-}
-
-async function deactivateUser(uid) {
-  if (!confirm('Деактивировать пользователя?')) return;
-  const d = await postJSON(`/admin/delete-user/${uid}`);
-  if (d.success) location.reload(); else showToast(d.error || 'Ошибка');
-}
-
+function openModal(id) { document.getElementById(id).style.display = 'flex'; }
+function closeModal(id) { document.getElementById(id).style.display = 'none'; }
 async function resetPassword(uid) {
-  const d = await postJSON(`/admin/reset-password/${uid}`);
-  if (d.success) showToast(`Новый пароль: ${d.new_password}`); else showToast(d.error || 'Ошибка');
-}
-
-async function deleteCategory(uid) {
-  if (!confirm('Деактивировать категорию/услугу?')) return;
-  const d = await postJSON(`/admin/delete-category/${uid}`);
-  if (d.success) location.reload(); else showToast(d.error || 'Ошибка');
-}
-
-async function createWorkGroup() {
-  const name = document.getElementById('wg_name').value.trim();
-  const desc = document.getElementById('wg_desc').value.trim();
-  if (!name) return showToast('Введите название группы');
-  const d = await postJSON('/admin/create-work-group', {group_name: name, group_description: desc});
-  if (d.success) location.reload(); else showToast(d.error || 'Ошибка');
-}
-
-async function deleteWorkGroup(uid) {
-  if (!confirm('Удалить рабочую группу?')) return;
-  const d = await postJSON(`/admin/delete-work-group/${uid}`);
-  if (d.success) location.reload(); else showToast(d.error || 'Ошибка');
-}
-
-async function createTicket() {
-  const catalog_uid = document.getElementById('new_catalog_uid').value;
-  const summary = document.getElementById('new_summary').value.trim();
-  const description = document.getElementById('new_description').value.trim();
-  const d = await postJSON('/api/tickets', {catalog_uid, summary, description});
-  if (d.success) {
-    showToast(`Заявка создана: ${d.ticket_number}`);
-    window.location.reload();
-  } else {
-    showToast(d.error || 'Ошибка');
-  }
+  const r = await fetch(`/admin/reset-password/${uid}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}'
+  });
+  const d = await r.json();
+  alert(d.success ? `Новый пароль: ${d.new_password}` : d.error || 'Ошибка');
 }

--- a/templates/admin_categories.html
+++ b/templates/admin_categories.html
@@ -8,12 +8,22 @@
     {% for cat in categories %}
     <tr>
       <td>{{ cat.catalog_name }}</td><td>{{ cat.catalog_type }}</td><td>{{ cat.work_group.group_name if cat.work_group else '—' }}</td><td>{{ cat.priority|priority_label }}</td><td>{{ 'Да' if cat.is_active else 'Нет' }}</td>
-      <td><a class="btn" href="{{ url_for('edit_category', cat_uid=cat.catalog_uid) }}">Редактировать</a> <button class="btn btn-danger" onclick="deleteCategory('{{ cat.catalog_uid }}')">Деактивировать</button></td>
+      <td>
+        <a class="btn" href="{{ url_for('edit_category', cat_uid=cat.catalog_uid) }}">Редактировать</a>
+        <form method="POST" action="/admin/delete-category/{{ cat.catalog_uid }}" onsubmit="return confirm('Деактивировать категорию/услугу?')" style="display:inline-block;">
+          <button class="btn btn-danger" type="submit">Деактивировать</button>
+        </form>
+      </td>
     </tr>
       {% for svc in cat._services %}
       <tr>
         <td>— {{ svc.catalog_name }}</td><td>{{ svc.catalog_type }}</td><td>{{ svc.work_group.group_name if svc.work_group else '—' }}</td><td>{{ svc.priority|priority_label }}</td><td>{{ 'Да' if svc.is_active else 'Нет' }}</td>
-        <td><a class="btn" href="{{ url_for('edit_category', cat_uid=svc.catalog_uid) }}">Редактировать</a> <button class="btn btn-danger" onclick="deleteCategory('{{ svc.catalog_uid }}')">Деактивировать</button></td>
+        <td>
+          <a class="btn" href="{{ url_for('edit_category', cat_uid=svc.catalog_uid) }}">Редактировать</a>
+          <form method="POST" action="/admin/delete-category/{{ svc.catalog_uid }}" onsubmit="return confirm('Деактивировать категорию/услугу?')" style="display:inline-block;">
+            <button class="btn btn-danger" type="submit">Деактивировать</button>
+          </form>
+        </td>
       </tr>
       {% endfor %}
     {% endfor %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -16,8 +16,12 @@
       <td>{{ 'Деактивирован' if u.is_deactivated else 'Активен' }}</td>
       <td class="actions">
         <a class="btn" href="{{ url_for('edit_user', user_uid=u.user_uid) }}">Редактировать</a>
-        <button class="btn" onclick="resetPassword('{{ u.user_uid }}')">Сброс пароля</button>
-        {% if u.user_uid != current_user.user_uid %}<button class="btn btn-danger" onclick="deactivateUser('{{ u.user_uid }}')">Деактивировать</button>{% endif %}
+        <button class="btn" type="button" onclick="resetPassword('{{ u.user_uid }}')">Сброс пароля</button>
+        {% if u.user_uid != current_user.user_uid %}
+          <form method="POST" action="/admin/delete-user/{{ u.user_uid }}" onsubmit="return confirm('Деактивировать?')">
+            <button class="btn btn-danger" type="submit">Деактивировать</button>
+          </form>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}

--- a/templates/admin_work_groups.html
+++ b/templates/admin_work_groups.html
@@ -3,17 +3,29 @@
 {% block content %}
 <div class="card">
   <h2>Рабочие группы</h2>
-  <div class="grid grid-2">
-    <input id="wg_name" placeholder="Название группы">
-    <input id="wg_desc" placeholder="Описание">
-  </div>
-  <div class="actions" style="margin-top:8px;"><button class="btn btn-primary" onclick="createWorkGroup()">Добавить</button></div>
+  <form method="POST" action="/admin/create-work-group">
+    <div class="grid grid-2">
+      <input name="group_name" placeholder="Название группы" required>
+      <input name="group_description" placeholder="Описание">
+    </div>
+    <div class="actions" style="margin-top:8px;"><button class="btn btn-primary" type="submit">Добавить</button></div>
+  </form>
 </div>
 <div class="card">
   <table class="table">
     <tr><th>Название</th><th>Описание</th><th>Действия</th></tr>
     {% for wg in groups %}
-    <tr><td>{{ wg.group_name }}</td><td>{{ wg.group_description or '—' }}</td><td>{% if wg.isactive %}<button class="btn btn-danger" onclick="deleteWorkGroup('{{ wg.work_group_uid }}')">Удалить</button>{% endif %}</td></tr>
+    <tr>
+      <td>{{ wg.group_name }}</td>
+      <td>{{ wg.group_description or '—' }}</td>
+      <td>
+        {% if wg.isactive %}
+        <form method="POST" action="/admin/delete-work-group/{{ wg.work_group_uid }}" onsubmit="return confirm('Удалить рабочую группу?')">
+          <button class="btn btn-danger" type="submit">Удалить</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
     {% endfor %}
   </table>
 </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,28 +2,39 @@
 {% block title %}Главная{% endblock %}
 {% block content %}
 <div class="card">
-  <h2>Создать заявку</h2>
-  <div class="grid grid-2">
-    <div>
-      <label>Услуга</label>
-      <select id="new_catalog_uid">
-        {% for cat in categories %}
-          {% for svc in cat._children %}
-          <option value="{{ svc.catalog_uid }}">{{ cat.catalog_name }} / {{ svc.catalog_name }}</option>
-          {% endfor %}
-        {% endfor %}
-      </select>
-    </div>
-    <div><label>Тема</label><input id="new_summary" type="text" placeholder="Кратко опишите проблему"></div>
+  <div class="inline" style="justify-content:space-between;">
+    <h2>Создание заявки</h2>
+    <button class="btn btn-primary" onclick="openModal('create-modal')">Новая заявка</button>
   </div>
-  <div style="margin-top:10px;"><label>Описание</label><textarea id="new_description" rows="4"></textarea></div>
-  <div class="actions" style="margin-top:10px;"><button class="btn btn-primary" onclick="createTicket()">Отправить</button></div>
+</div>
+
+<div id="create-modal" style="display:none;position:fixed;inset:0;background:rgba(15,23,42,.5);align-items:center;justify-content:center;padding:16px;z-index:50;">
+  <div class="card" style="width:100%;max-width:700px;">
+    <div class="inline" style="justify-content:space-between;"><h3>Новая заявка</h3><button class="btn" type="button" onclick="closeModal('create-modal')">Закрыть</button></div>
+    <form method="POST" action="/tickets/new">
+      <div class="grid grid-2">
+        <div>
+          <label>Услуга</label>
+          <select name="catalog_uid" required>
+            {% for cat in categories %}
+              {% for svc in cat._children %}
+              <option value="{{ svc.catalog_uid }}">{{ cat.catalog_name }} / {{ svc.catalog_name }}</option>
+              {% endfor %}
+            {% endfor %}
+          </select>
+        </div>
+        <div><label>Тема</label><input name="summary" type="text" placeholder="Кратко опишите проблему" required></div>
+      </div>
+      <div style="margin-top:10px;"><label>Описание</label><textarea name="description" rows="4" required></textarea></div>
+      <div class="actions" style="margin-top:10px;"><button class="btn btn-primary" type="submit">Отправить</button></div>
+    </form>
+  </div>
 </div>
 
 <div class="card">
   <h3>Каталог услуг</h3>
   {% for cat in categories %}
-    <p><strong>{{ cat.catalog_name }}</strong>: 
+    <p><strong>{{ cat.catalog_name }}</strong>:
     {% for svc in cat._children %}
       <span class="badge">{{ svc.catalog_name }}</span>
     {% else %}
@@ -37,7 +48,7 @@
   <h3>Мои заявки</h3>
   <table class="table">
     <tr><th>Номер</th><th>Тема</th><th>Статус</th><th>Создана</th></tr>
-    {% for t in my_tickets %}<tr><td>{{ t.ticket_number }}</td><td>{{ t.summary }}</td><td>{{ t.status|status_label }}</td><td>{{ t.created_at|datefmt }}</td></tr>{% endfor %}
+    {% for t in my_tickets %}<tr><td><a href="/ticket/{{ t.ticket_uid }}">{{ t.ticket_number }}</a></td><td>{{ t.summary }}</td><td>{{ t.status|status_label }}</td><td>{{ t.created_at|datefmt }}</td></tr>{% endfor %}
   </table>
 </div>
 {% endif %}
@@ -47,7 +58,7 @@
   <h3>Результаты поиска: {{ q }}</h3>
   <table class="table">
     <tr><th>Номер</th><th>Тема</th><th>Статус</th></tr>
-    {% for t in search_results %}<tr><td>{{ t.ticket_number }}</td><td>{{ t.summary }}</td><td>{{ t.status|status_label }}</td></tr>{% endfor %}
+    {% for t in search_results %}<tr><td><a href="/ticket/{{ t.ticket_uid }}">{{ t.ticket_number }}</a></td><td>{{ t.summary }}</td><td>{{ t.status|status_label }}</td></tr>{% endfor %}
   </table>
 </div>
 {% endif %}

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block title %}{{ ticket.ticket_number }}{% endblock %}
+{% block content %}
+<div class="card">
+  <h2>{{ ticket.ticket_number }} — {{ ticket.summary }}</h2>
+  <p>{{ ticket.description }}</p>
+  <p>
+    <span class="badge">{{ ticket.status|status_label }}</span>
+    <span class="badge">{{ ticket.priority|priority_label }}</span>
+    <span class="muted">Создана: {{ ticket.created_at|datefmt }}</span>
+  </p>
+  <p><strong>Заявитель:</strong> {{ ticket.requester.full_name() if ticket.requester else '—' }}</p>
+  <p><strong>Исполнитель:</strong> {{ ticket.performer.full_name() if ticket.performer else 'не назначен' }}</p>
+</div>
+
+<div class="card">
+  <h3>Комментарии</h3>
+  {% for c in comments %}
+    <p><strong>{{ c.author_rel.full_name() if c.author_rel else '—' }}</strong> <span class="muted">{{ c.create_date|datefmt }}</span><br>{{ c.param_value }}</p>
+  {% else %}
+    <p class="muted">Комментариев пока нет.</p>
+  {% endfor %}
+</div>
+
+{% if current_user.role in ('specialist', 'manager', 'admin') %}
+<div class="card">
+  <h3>Обновить заявку</h3>
+  <form method="POST" action="/ticket/{{ ticket.ticket_uid }}/update">
+    <div class="grid grid-2">
+      <div>
+        <label>Статус</label>
+        <select name="status">
+          <option value="new" {% if ticket.status == 'new' %}selected{% endif %}>Новая</option>
+          <option value="in_progress" {% if ticket.status == 'in_progress' %}selected{% endif %}>В работе</option>
+          <option value="resolved" {% if ticket.status == 'resolved' %}selected{% endif %}>Решена</option>
+          <option value="cancelled" {% if ticket.status == 'cancelled' %}selected{% endif %}>Отменена</option>
+        </select>
+      </div>
+      {% if current_user.role in ('manager', 'admin') %}
+      <div>
+        <label>Исполнитель</label>
+        <select name="performer_uid">
+          <option value="">не назначен</option>
+          {% for s in specialists %}
+            <option value="{{ s.user_uid }}" {% if ticket.performer_uid == s.user_uid %}selected{% endif %}>{{ s.full_name() }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      {% endif %}
+    </div>
+    <div class="actions" style="margin-top:10px;"><button class="btn btn-primary" type="submit">Сохранить</button></div>
+  </form>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -17,7 +17,7 @@
     <tr><th>Номер</th><th>Тема</th><th>Категория</th><th>Статус</th><th>Приоритет</th><th>Исполнитель</th><th>Создана</th></tr>
     {% for t in tickets %}
     <tr>
-      <td>{{ t.ticket_number }}</td>
+      <td><a href="/ticket/{{ t.ticket_uid }}">{{ t.ticket_number }}</a></td>
       <td>{{ t.summary }}</td>
       <td>{{ t.catalog.catalog_name if t.catalog else '—' }}</td>
       <td>{{ t.status|status_label }}</td>


### PR DESCRIPTION
### Motivation
- Remove fragile dual-path that attempted to call Postgres stored procedures from Python helpers and keep a single clear Python implementation for user/login/password operations.
- Simplify the ticket management UX by replacing small JS-driven fetch flows with plain HTML forms and a minimal ticket detail/edit page for student-friendly operation.
- Convert admin JS actions into standard form POSTs so admin pages work without API-only JS and support both JSON API and form-based submissions.

### Description
- Removed attempts to call DB-side stored procedures in `models.py` (`generate_login`, `generate_password`, `create_user_db`, `reset_password_db`) and kept the pure-Python implementations; added `func` import and switched `generate_ticket_number()` to use `db.session.query(func.count(...))`.
- Added three simple form routes in `app.py`: `POST /tickets/new` to create tickets from a form, `GET /ticket/<ticket_uid>` to render a new `ticket_detail.html` page, and `POST /ticket/<ticket_uid>/update` to accept status/performer updates from that form.
- Introduced `templates/ticket_detail.html` showing core ticket info, comments, and a compact update form; updated `templates/home.html` to open a modal form posting to `/tickets/new` and updated `templates/tickets.html` to link ticket numbers to the detail page.
- Reworked admin templates (`admin_users.html`, `admin_categories.html`, `admin_work_groups.html`) to use plain HTML `<form method="POST">` buttons for delete/deactivate/create actions, and adjusted corresponding `app.py` routes to return JSON for API callers and redirect+flash for normal form submissions.
- Rewrote `static/js/main.js` to only provide two modal helpers and `resetPassword` (now 9 lines), removing other fetch-based helpers.

### Testing
- Ran syntax check with `python -m py_compile app.py models.py` and it completed without errors.
- Verified `static/js/main.js` line count with `wc -l static/js/main.js` which reported `9`, meeting the ≤20-line target.
- Performed lightweight runtime checks by starting basic code paths (template rendering and form handlers) during development and ensured no exceptions were raised during the automated checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbaf52663c8323b678631bf725e35e)