### PR TITLE
Remove unused avatar code and add server-side ticket comment form

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,8 +265,7 @@ def init_db():
     # Lightweight compatibility migration for older databases.
     db.session.execute(text("""
         ALTER TABLE IF EXISTS sm.users
-            ADD COLUMN IF NOT EXISTS manager_uid uuid NULL,
-            ADD COLUMN IF NOT EXISTS avatar varchar(32) NULL DEFAULT 'cat'
+            ADD COLUMN IF NOT EXISTS manager_uid uuid NULL
     """))
     db.session.execute(text("""
         ALTER TABLE IF EXISTS sm.service_catalog
@@ -1180,6 +1179,34 @@ def add_comment(ticket_uid):
             'created_at': datetime.utcnow().strftime('%d.%m.%Y %H:%M'),
         }
     })
+
+
+@app.route('/ticket/<ticket_uid>/add_comment', methods=['POST'])
+@login_required
+def add_comment_form(ticket_uid):
+    ticket = Ticket.query.get_or_404(ticket_uid)
+    if not _can_view_ticket(ticket):
+        flash('Доступ запрещён', 'error')
+        return redirect(f'/ticket/{ticket_uid}')
+    text = (request.form.get('text') or '').strip()
+    if not text:
+        flash('Комментарий не может быть пустым', 'error')
+        return redirect(f'/ticket/{ticket_uid}')
+    db.session.add(TicketParamValue(
+        ticket_uid=ticket_uid,
+        param_name='comment',
+        param_value=text,
+        param_type='comment',
+        author_uid=current_user.user_uid,
+    ))
+    ticket.updated_at = datetime.utcnow()
+    ticket.updated_by = current_user.user_uid
+    notify_ticket_update(ticket,
+                         f'Новый комментарий к заявке {ticket.ticket_number}',
+                         exclude_uid=current_user.user_uid)
+    db.session.commit()
+    flash('Комментарий добавлен', 'success')
+    return redirect(f'/ticket/{ticket_uid}')
 
 
 # ============================================================

--- a/models.py
+++ b/models.py
@@ -4,12 +4,6 @@ from flask_login import UserMixin
 from datetime import datetime
 
 db = SQLAlchemy()
-AVATAR_EMOJIS = {
-    'cat': '🐱', 'dog': '🐶', 'fox': '🦊', 'bear': '🐻', 'penguin': '🐧',
-    'owl': '🦉', 'tiger': '🐯', 'rabbit': '🐰', 'wolf': '🐺', 'panda': '🐼',
-    'frog': '🐸', 'lion': '🦁', 'koala': '🐨', 'duck': '🦆', 'dragon': '🐲',
-}
-
 
 def gen_uuid():
     return str(uuid.uuid4())
@@ -35,7 +29,6 @@ class User(UserMixin, db.Model):
     department = db.Column(db.String(255), nullable=True)
     company = db.Column(db.String(255), nullable=True)
     manager_uid = db.Column(db.String(36), db.ForeignKey('sm.users.user_uid'), nullable=True)
-    avatar = db.Column(db.String(32), nullable=False, default='cat')
     work_status = db.Column(db.String(20), nullable=True)
     is_vip = db.Column(db.Boolean, default=False)
     is_deactivated = db.Column(db.Boolean, default=False)
@@ -510,7 +503,7 @@ def generate_ticket_number() -> str:
 def create_user_db(last_name, first_name, middle_name, email, mobile,
                    work_phone, gender, title, department, company,
                    role='user', work_group_uid=None, manager_uid=None,
-                   creator_uid=None, avatar='cat') -> tuple:
+                   creator_uid=None) -> tuple:
     """
     Creates a user.
 
@@ -535,7 +528,6 @@ def create_user_db(last_name, first_name, middle_name, email, mobile,
         department=department or None,
         company=company or None,
         manager_uid=manager_uid,
-        avatar=avatar or 'cat',
         create_by=sys_uid,
         update_by=sys_uid,
     )

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -25,7 +25,6 @@ CREATE TABLE IF NOT EXISTS sm.users (
     department      varchar(255) NULL,
     company         varchar(255) NULL,
     manager_uid     uuid NULL,
-    avatar          varchar(32) DEFAULT 'cat' NULL,
     work_status     varchar(20)  NULL,
     is_vip          bool         DEFAULT false NULL,
     is_deactivated  bool         DEFAULT false NULL,

--- a/templates/ticket_detail.html
+++ b/templates/ticket_detail.html
@@ -20,6 +20,14 @@
   {% else %}
     <p class="muted">Комментариев пока нет.</p>
   {% endfor %}
+
+  <form method="POST" action="/ticket/{{ ticket.ticket_uid }}/add_comment" style="margin-top:12px;">
+    <label>Добавить комментарий</label>
+    <textarea name="text" rows="3" placeholder="Напишите комментарий..." required style="width:100%;"></textarea>
+    <div class="actions" style="margin-top:8px;">
+      <button class="btn btn-primary" type="submit">Отправить</button>
+    </div>
+  </form>
 </div>
 
 {% if current_user.role in ('specialist', 'manager', 'admin') %}


### PR DESCRIPTION
### Motivation

- Remove dead avatar-related code and schema to simplify the codebase because avatars are not used anywhere in templates or UI.
- Stop mapping a deprecated `avatar` column in the ORM and avoid passing `avatar` into user-creation helpers to reduce confusion and maintenance burden.
- Provide a non-JS path for adding ticket comments so users who don't run client-side JS can still submit comments.

### Description

- Deleted `AVATAR_EMOJIS`, removed the `avatar` column from the `User` model, and removed the `avatar` parameter and usage from `create_user_db` in `models.py`.
- Removed the `avatar` line from the lightweight `ALTER TABLE` compatibility migration in `init_db()` (`app.py`) and removed the `avatar` column from `sql/01_schema.sql` so new schema/init won't add it.
- Added a new server-side route `POST /ticket/<ticket_uid>/add_comment` (`add_comment_form`) in `app.py` that enforces `_can_view_ticket`, validates non-empty `text`, stores a `TicketParamValue` of type `comment`, updates ticket timestamps, triggers `notify_ticket_update`, and uses `flash` + redirect.
- Added a simple HTML comment form to `templates/ticket_detail.html` that posts to `/ticket/{{ ticket.ticket_uid }}/add_comment` so comments can be submitted without JavaScript.

### Testing

- Ran `python -m py_compile app.py models.py` which completed successfully.
- Verified the routes with `flask --app app routes` and confirmed both the existing API `POST /api/tickets/<ticket_uid>/comment` and the new `POST /ticket/<ticket_uid>/add_comment` route are registered.
- Searched the codebase with `rg` for `AVATAR_EMOJIS` and `avatar` in `*.py`/`*.html` and found no remaining references in the application code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de608cd1708323adcde4d92f80388c)